### PR TITLE
CORE-8407: ES v5.0 Upgrade

### DIFF
--- a/src/monkey/index.clj
+++ b/src/monkey/index.clj
@@ -17,7 +17,7 @@
   [props es]
   (let [res (doc/search es (props/es-index props) (props/es-tag-type props)
               :query       (query/match-all)
-              :fields      ["_id"]
+              :_source     ["_id"]
               :sort        ["_doc"]
               :scroll      (props/es-scroll-timeout props)
               :size        (props/es-scroll-size props))]

--- a/src/monkey/index.clj
+++ b/src/monkey/index.clj
@@ -18,7 +18,7 @@
   (let [res (doc/search es (props/es-index props) (props/es-tag-type props)
               :query       (query/match-all)
               :fields      ["_id"]
-              :search_type "scan"
+              :sort        ["_doc"]
               :scroll      (props/es-scroll-timeout props)
               :size        (props/es-scroll-size props))]
     (if (resp/any-hits? res)


### PR DESCRIPTION
This PR contains updates to the terrain service to ensure that it's search features are API compatible with ES v5.0. The list below describes the [API Breaking Changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes-5.0.html) which were fixed as part of this PR.

- [x] `fields` parameter changed
- [x] `search_type=scan` removed