### PR TITLE
Add ability to use basic auth with Elasticsearch

### DIFF
--- a/monkey.properties.tmpl
+++ b/monkey.properties.tmpl
@@ -8,6 +8,8 @@
 {{ with $v := (key (printf "%s/monkey/queue" $base)) }}monkey.amqp.queue = {{ $v }}{{ end }}
 
 {{ with $v := (key (printf "%s/elasticsearch/base" $base)) }}monkey.es.url = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/elasticsearch/username" $base)) }}monkey.es.user = {{ $v }}{{ end }}
+{{ with $v := (key (printf "%s/elasticsearch/password" $base)) }}monkey.es.password = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/data-alias" $base)) }}monkey.es.index = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/batch-size" $base)) }}monkey.es.batch-size = {{ $v }}{{ end }}
 {{ with $v := (key (printf "%s/elasticsearch/scroll-size" $base)) }}monkey.es.scroll-size = {{ $v }}{{ end }}

--- a/src/monkey/index.clj
+++ b/src/monkey/index.clj
@@ -127,5 +127,9 @@
    Returns:
      It returns the object."
   [^PersistentArrayMap props]
-  (->Index props
-           (es/connect (str (props/es-url props)))))
+  (let [url (str (props/es-url props))
+        http-opts (if (or (empty? (props/es-user props)) (empty? (props/es-password props)))
+                    {}
+                    {:basic-auth [(props/es-user props) (props/es-password props)]})]
+    (->Index props
+             (es/connect url http-opts))))

--- a/src/monkey/props.clj
+++ b/src/monkey/props.clj
@@ -130,6 +130,28 @@
   [^PersistentArrayMap props]
   (URL. (string/trim (get-prop props "monkey.es.url"))))
 
+(defn ^String es-user
+  "Returns the user for authentication with elasticsearch.
+
+   Parameters:
+     props - the property map to use
+
+   Returns:
+     the elasticsearch username"
+  [^PersistentArrayMap props]
+  (get-prop props "monkey.es.user"))
+
+(defn ^String es-password
+  "Returns the password for authentication with elasticsearch.
+
+   Parameters:
+     props - the property map to use
+
+   Returns:
+     the elasticsearch password"
+  [^PersistentArrayMap props]
+  (get-prop props "monkey.es.password"))
+
 
 (defn ^String es-index
   "Returns the index in elasticsearch where the tags are indexed.


### PR DESCRIPTION
Intended behavior is to only use the basic auth when the configuration supplied Elasticsearch username and password are non-empty.